### PR TITLE
Implement paging when getting collections

### DIFF
--- a/lib/firestore/firestore_gateway.dart
+++ b/lib/firestore/firestore_gateway.dart
@@ -24,15 +24,18 @@ class FirestoreGateway {
     _setupClient();
   }
 
-  Future<List<Document>> getCollection(String path) async {
+  Future<Page<Document>> getCollection(
+      String path, int pageSize, String nextPageToken) async {
     var request = ListDocumentsRequest()
       ..parent = path.substring(0, path.lastIndexOf('/'))
-      ..collectionId = path.substring(path.lastIndexOf('/') + 1);
+      ..collectionId = path.substring(path.lastIndexOf('/') + 1)
+      ..pageSize = pageSize
+      ..pageToken = nextPageToken;
     var response =
         await _client.listDocuments(request).catchError(_handleError);
-    return response.documents
-        .map((rawDocument) => Document(this, rawDocument))
-        .toList(growable: false);
+    var documents =
+        response.documents.map((rawDocument) => Document(this, rawDocument));
+    return Page(documents, response.nextPageToken);
   }
 
   Stream<List<Document>> streamCollection(String path) {

--- a/lib/firestore/models.dart
+++ b/lib/firestore/models.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:firedart/generated/google/firestore/v1/document.pb.dart' as fs;
 import 'package:firedart/generated/google/protobuf/struct.pbenum.dart';
 import 'package:firedart/generated/google/protobuf/timestamp.pb.dart';
@@ -62,7 +64,9 @@ class CollectionReference extends Reference {
     return DocumentReference(_gateway, '$path/$id');
   }
 
-  Future<List<Document>> get() => _gateway.getCollection(_fullPath);
+  Future<Page<Document>> get(
+          {int pageSize = 1024, String nextPageToken = ''}) =>
+      _gateway.getCollection(_fullPath, pageSize, nextPageToken);
 
   Stream<List<Document>> get stream => _gateway.streamCollection(_fullPath);
 
@@ -171,6 +175,29 @@ class GeoPoint {
   LatLng _toLatLng() => LatLng()
     ..latitude = latitude
     ..longitude = longitude;
+}
+
+class Page<T> extends ListBase<T> {
+  final _list = <T>[];
+  final String nextPageToken;
+
+  bool get hasNextPage => nextPageToken.isNotEmpty;
+
+  @override
+  int get length => _list.length;
+
+  @override
+  set length(int newLength) => _list.length = newLength;
+
+  @override
+  T operator [](int index) => _list[index];
+
+  @override
+  void operator []=(int index, T value) => _list[index] = value;
+
+  Page(Iterable<T> iterable, this.nextPageToken) {
+    _list.addAll(iterable);
+  }
 }
 
 fs.Value _encode(dynamic value) {

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -30,6 +30,23 @@ Future main() async {
     expect(documents.isNotEmpty, true);
   });
 
+  test('Limit collection page size', () async {
+    var reference = firestore.collection('test');
+    var documents = await reference.get(pageSize: 1);
+    expect(documents.length, 1);
+    expect(documents.hasNextPage, isTrue);
+  });
+
+  test('Get next collection page', () async {
+    var reference = firestore.collection('test');
+    var documents = await reference.get(pageSize: 1);
+    var first = documents[0];
+    documents = await reference.get(
+        pageSize: 1, nextPageToken: documents.nextPageToken);
+    var second = documents[0];
+    expect(first.id, isNot(second.id));
+  });
+
   test('Add and delete collection document', () async {
     var reference = firestore.collection('test');
     var docReference = await reference.add({'field': 'test'});


### PR DESCRIPTION
- Returns a Page object containing paging metadata
- Allow setting page size on requests
- Allow requesting next page using the relevant token
- Set default page size to 1024 items

Fixes #16