### PR TITLE
implement signInAnonymously for FirebaseAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dependencies:
 
 ## Firebase Auth
 
-The `FirebaseAuth` class implements the necessary functionality for managing accounts. It currently only supports `Email/Password` sign-in, so make sure it's enabled under `Authentication` -> `Sign-in Method`.
+The `FirebaseAuth` class implements the necessary functionality for managing accounts. It currently only supports `Email/Password` sign-in and `anonymous` sign-in, so make sure these are enabled under `Authentication` -> `Sign-in Method`.
 
 You'll also need to go to your `Firebase Console`, open `Project Settings` and under the `General` tab copy the `Web API Key`.
 

--- a/lib/auth/auth_gateway.dart
+++ b/lib/auth/auth_gateway.dart
@@ -18,6 +18,17 @@ class AuthGateway {
   Future<User> signIn(String email, String password) async =>
       _auth('signInWithPassword', email, password);
 
+  Future<User> signInAnonymously() async {
+    var map = await _post(
+      'signUp',
+      {
+        'returnSecureToken': 'true',
+      },
+    );
+    tokenProvider.setToken(map);
+    return User.fromMap(map);
+  }
+
   Future<void> resetPassword(String email) => _post('sendOobCode', {
         'requestType': 'PASSWORD_RESET',
         'email': email,

--- a/lib/auth/firebase_auth.dart
+++ b/lib/auth/firebase_auth.dart
@@ -57,6 +57,8 @@ class FirebaseAuth {
   Future<User> signIn(String email, String password) =>
       _authGateway.signIn(email, password);
 
+  Future<User> signInAnonymously() => _authGateway.signInAnonymously();
+
   void signOut() => tokenProvider.signOut();
 
   Future<void> resetPassword(String email) => _authGateway.resetPassword(email);

--- a/test/firebase_auth_test.dart
+++ b/test/firebase_auth_test.dart
@@ -21,6 +21,14 @@ Future main() async {
     expect(auth.isSignedIn, false);
   });
 
+  test('Sign In Anonymously', () async {
+    expect(auth.isSignedIn, false);
+    await auth.signInAnonymously();
+    expect(auth.isSignedIn, true);
+    auth.signOut();
+    expect(auth.isSignedIn, false);
+  });
+
   test('Fail sign-in on invalid email', () async {
     await expectLater(
         auth.signIn('bademail.com', 'bad_pass'), throwsA(isA<AuthException>()));
@@ -47,6 +55,11 @@ Future main() async {
 
   test('Get user id', () async {
     await auth.signIn(email, password);
+    expect(auth.userId, isNotEmpty);
+  });
+
+  test('Get anonymous user id', () async {
+    await auth.signInAnonymously();
     expect(auth.userId, isNotEmpty);
   });
 


### PR DESCRIPTION
With this PR I implemented the possibility to sign in anonymously and added some basics tests for it. 
Should we duplicate more tests like token refresh, which currently testing signIn only ?  