### PR TITLE
Removed unnecessary print

### DIFF
--- a/lib/firestore/firestore_gateway.dart
+++ b/lib/firestore/firestore_gateway.dart
@@ -234,7 +234,6 @@ class FirestoreGateway {
   }
 
   void _handleError(e) {
-    print('Handling error $e using FirestoreGateway._handleError');
     if (e is GrpcError &&
         [
           StatusCode.unknown,


### PR DESCRIPTION
Even if the exception is caught by application code this print made it look like something went wrong anyway which was a bit confusing.