### PR TITLE
Add web support

### DIFF
--- a/lib/firestore/firestore.dart
+++ b/lib/firestore/firestore.dart
@@ -1,6 +1,7 @@
 import 'package:firedart/auth/firebase_auth.dart';
 import 'package:firedart/firestore/application_default_authenticator.dart';
 import 'package:firedart/firestore/token_authenticator.dart';
+import 'package:grpc/grpc.dart';
 
 import 'firestore_gateway.dart';
 import 'models.dart';
@@ -16,11 +17,15 @@ class Firestore {
   /* Singleton interface */
   static Firestore? _instance;
 
+  /// Supply [webProxyHost] and [webProxyPort] if you want your app to run on
+  /// the web and have setup a grpc-web->grpc proxy.
   static Firestore initialize(
     String projectId, {
     bool useApplicationDefaultAuth = false,
     String? databaseId,
     Emulator? emulator,
+    String? webProxyHost,
+    int? webProxyPort,
   }) {
     if (initialized) {
       throw Exception('Firestore instance was already initialized');
@@ -45,6 +50,9 @@ class Firestore {
       databaseId: databaseId,
       authenticator: authenticator,
       emulator: emulator,
+      webProxy: webProxyHost == null
+          ? null
+          : Proxy(host: webProxyHost, port: webProxyPort!),
     );
     return _instance!;
   }
@@ -67,12 +75,12 @@ class Firestore {
     String? databaseId,
     RequestAuthenticator? authenticator,
     Emulator? emulator,
-  })  : _gateway = FirestoreGateway(
-          projectId,
-          databaseId: databaseId,
-          authenticator: authenticator,
-          emulator: emulator,
-        ),
+    Proxy? webProxy,
+  })  : _gateway = FirestoreGateway(projectId,
+            databaseId: databaseId,
+            authenticator: authenticator,
+            emulator: emulator,
+            grpcWebProxy: webProxy),
         assert(projectId.isNotEmpty);
 
   Reference reference(String path) => Reference.create(_gateway, path);

--- a/lib/firestore/firestore_gateway.dart
+++ b/lib/firestore/firestore_gateway.dart
@@ -5,6 +5,7 @@ import 'package:firedart/generated/google/firestore/v1/document.pb.dart' as fs;
 import 'package:firedart/generated/google/firestore/v1/firestore.pbgrpc.dart';
 import 'package:firedart/generated/google/firestore/v1/query.pb.dart';
 import 'package:grpc/grpc.dart';
+import 'package:grpc/grpc_or_grpcweb.dart';
 
 import '../firedart.dart';
 
@@ -20,7 +21,7 @@ class FirestoreGateway {
 
   late FirestoreClient _client;
 
-  late ClientChannel _channel;
+  late GrpcOrGrpcWebClientChannel _channel;
 
   FirestoreGateway(
     String projectId, {
@@ -162,11 +163,11 @@ class FirestoreGateway {
         : null;
     _listenStreamCache.clear();
     _channel = emulator == null
-        ? ClientChannel(
+        ? GrpcOrGrpcWebClientChannel.grpc(
             'firestore.googleapis.com',
             options: ChannelOptions(),
           )
-        : ClientChannel(
+        : GrpcOrGrpcWebClientChannel.grpc(
             emulator.host,
             port: emulator.port,
             options: ChannelOptions(


### PR DESCRIPTION
This change adds support for web apps because browsers only speak
grpc-web, not grpc.

We now use GrpcOrGrpcWebClientChannel which
works just like the previously used ClientChannel when not on web.

Fixes #134 

I've setup an envoy proxy to test the grpc-web client but still wrestling with that a bit.  I'd like to set up a test that uses the emulator and a local docker container that could be run in CI. It would be good to get feedback on #136 then if you agree I could do that first then create tests for this PR.